### PR TITLE
add multiline user map and exclusion label

### DIFF
--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -14,6 +14,7 @@ jobs:
       with:
         webhook-url: ${{ secrets.TEAMS_WEBHOOK }}
         provider: 'msteams'
+        ignore-label: no-reminder
         github-provider-map: >
           apetsche1:apetsche@illinois.edu,
           asvalent:asvalent@illinois.edu,

--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -14,4 +14,5 @@ jobs:
       with:
         webhook-url: ${{ secrets.TEAMS_WEBHOOK }}
         provider: 'msteams'
+        ignore-label: no-reminder
         github-provider-map: "apetsche1:apetsche@illinois.edu,asvalent:asvalent@illinois.edu,mabaumgartner:mab@illinois.edu,wennebo1:wennebo1@illinois.edu"


### PR DESCRIPTION
version 2.2.2 did not work but 2.2.3 (latest) seems to work fine.

Testing multiline user map and a label exclusion to silence reminders